### PR TITLE
Added rules to distribute share/ directory on 'make install'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = src doc tests bindings
+SUBDIRS = src doc tests bindings share
 
 EXTRA_DIST = README.md share/protor.config share/naccess.config share/dssp.config share/oons.config \
 	scripts/chemcomp2config.pl scripts/config2c.pl

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ AC_FUNC_REALLOC
 AC_CHECK_FUNCS([memset mkdir sqrt strchr strdup strerror getopt_long getline])
 
 AC_CONFIG_FILES([Makefile src/Makefile doc/Makefile doc/Doxyfile
-                 tests/Makefile bindings/Makefile
+                 tests/Makefile bindings/Makefile share/Makefile
                  bindings/python/setup.py])
 AC_CONFIG_FILES([tests/test-cli], [chmod +x tests/test-cli])
 AC_CONFIG_FILES([bindings/check-python], [chmod +x bindings/check-python])

--- a/share/Makefile.am
+++ b/share/Makefile.am
@@ -1,0 +1,18 @@
+AM_LDFLAGS = 
+
+if COND_GCOV
+AM_CFLAGS = --coverage
+AM_LDFLAGS += -lgcov
+endif # COND_GCOV
+
+GCOV_FILES = *.gcda *.gcno *.gcov
+
+CLEANFILES = $(GCOV_FILES) *~
+
+clean-local:
+	-rm -rf *.dSYM
+
+
+dataroot_DATA = dssp.config naccess.config oons.config protor.config
+
+


### PR DESCRIPTION
Running 'make install' from either the git source or the distribution does not copy the data files in share/ and makes it harder to link to these when running the code. I hacked my way through the other Makefile.am files to make these changes, so it would be nicer if another (more experienced) pair of eyes could go over them!