### PR TITLE
Removing false positive detection of H-atoms

### DIFF
--- a/src/pdb.c
+++ b/src/pdb.c
@@ -149,9 +149,11 @@ freesasa_pdb_get_atom_name(char *name,
     assert(line);
     if (pdb_line_check(line,PDB_ATOM_NAME_STRL+12) == FREESASA_FAIL) {
         name[0] = '\0';
+        printf("Failed : %s\n", line);
         return FREESASA_FAIL;
     }
     strncpy(name,line+12,PDB_ATOM_NAME_STRL);
+    printf("%s\n", name );
     name[PDB_ATOM_NAME_STRL] = '\0';
     return FREESASA_SUCCESS;
 }
@@ -265,10 +267,13 @@ freesasa_pdb_ishydrogen(const char* line)
 {
     assert(line);
     if (pdb_line_check(line,13) == FREESASA_FAIL) return FREESASA_FAIL;
+    //false positive hydrogen
+    if (line[12] != 'H' && (line[13] == 'H' ||  line[13] == 'D')) return 0;
     //hydrogen
     if (line[12] == 'H' || line[13] == 'H') return 1;
     //hydrogen
     if (line[12] == 'D' || line[13] == 'D') return 1;
+
     return 0;
 }
 


### PR DESCRIPTION
In the function 'freesasa_pdb_ishydrogen', the method of detecting h-atoms resulted into some non-H atoms being discarded. For example, oxygen atoms (OD, OD1, etc.) and carbon atoms (CD, CD1, etc.). I have added an extra line of if-statement that corrects for that.

Kindly consider.