### PR TITLE
`.TH` should contain executable name

### DIFF
--- a/doc/man/freesasa.1.in
+++ b/doc/man/freesasa.1.in
@@ -1,5 +1,5 @@
 .\" Man page for FressSASA
-.TH man 1 "2017" "@PACKAGE_VERSION@" "FreeSASA man page"
+.TH freesasa 1 "2017" "@PACKAGE_VERSION@" "FreeSASA man page"
 .SH NAME
 FreeSASA @PACKAGE_VERSION@ - calculate Solvent Accessible Surface Areas from PDB files
 .SH SYNOPSIS


### PR DESCRIPTION
This fixes a minor issue with a manpage. `.TH` header is supposed to contain executable name, which now is given as `man` (should be `freesasa` instead).