### PR TITLE
Add installation instructions for homebrew and conda / mamba / pixi

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,25 @@ For developers:
   repository, so no need to do this if you are not going to change
   the parser).
 
+### Installing using package managers
+
+You can install binaries that have already been built using the package managers.
+
+With homebrew on MacOS (amd64, arm64) or Linux (amd64):
+
+    brew install brewsci/bio/freesasa
+
+With conda, mamba or pixi on Linux (amd64, arm64, ppc64le) or MacOS (amd64, arm64):
+
+    # conda
+    conda install -c conda-forge freesasa-c
+
+    # mamba
+    mamba install -c conda-forge freesasa-c
+
+    # pixi
+    pixi add freesasa-c
+
 ## Python module
 
 The Python bindings are available from PyPi and can be installed using


### PR DESCRIPTION
I think it could be helpful to users of these package managers if the README includeds installation instructions using the package managers.

---

This pull request updates the `README.md` file to include instructions for installing binaries using package managers. 

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R92-R110): Added a new section, "Installing using package managers," with detailed instructions for installing pre-built binaries using Homebrew, Conda, Mamba, and Pixi on MacOS and Linux platforms.